### PR TITLE
Define inspect methods for reqs & responses. Cherry pick of e3e02f4 to 1.8.x branch

### DIFF
--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -7,6 +7,10 @@ module RestClient
 
     attr_reader :net_http_res, :args, :request
 
+    def inspect
+      raise NotImplementedError.new('must override in subclass')
+    end
+
     # HTTP status code
     def code
       @code ||= @net_http_res.code.to_i

--- a/lib/restclient/raw_response.rb
+++ b/lib/restclient/raw_response.rb
@@ -15,6 +15,10 @@ module RestClient
 
     attr_reader :file, :request
 
+    def inspect
+      "<RestClient::RawResponse @code=#{code.inspect}, @file=#{file.inspect}, @request=#{request.inspect}>"
+    end
+
     def initialize(tempfile, net_http_res, args, request)
       @net_http_res = net_http_res
       @args = args

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -44,6 +44,10 @@ module RestClient
     SSLOptionList = %w{client_cert client_key ca_file ca_path cert_store
                        version ciphers verify_callback verify_callback_warnings}
 
+    def inspect
+      "<RestClient::Request @method=#{@method.inspect}, @url=#{@url.inspect}>"
+    end
+
     def initialize args
       @method = args[:method] or raise ArgumentError, "must pass :method"
       @headers = args[:headers] || {}

--- a/lib/restclient/response.rb
+++ b/lib/restclient/response.rb
@@ -6,8 +6,36 @@ module RestClient
 
     include AbstractResponse
 
+    # Return the HTTP response body.
+    #
+    # Future versions of RestClient will deprecate treating response objects
+    # directly as strings, so it will be necessary to call `.body`.
+    #
+    # @return [String]
+    #
     def body
-      @body ||= String.new(self)
+      # Benchmarking suggests that "#{self}" is fastest, and that caching the
+      # body string in an instance variable doesn't make it enough faster to be
+      # worth the extra memory storage.
+      String.new(self)
+    end
+
+    # Convert the HTTP response body to a pure String object.
+    #
+    # @return [String]
+    def to_s
+      body
+    end
+
+    # Convert the HTTP response body to a pure String object.
+    #
+    # @return [String]
+    def to_str
+      body
+    end
+
+    def inspect
+      "<RestClient::Response #{code.inspect} #{body_truncated(10).inspect}>"
     end
 
     def self.create body, net_http_res, args, request
@@ -17,5 +45,31 @@ module RestClient
       result
     end
 
+    private
+
+    def self.fix_encoding(response)
+      charset = RestClient::Utils.get_encoding_from_headers(response.headers)
+      encoding = nil
+
+      begin
+        encoding = Encoding.find(charset) if charset
+      rescue ArgumentError
+        RestClient.log "No such encoding: #{charset.inspect}"
+      end
+
+      return unless encoding
+
+      response.force_encoding(encoding)
+
+      response
+    end
+
+    def body_truncated(length)
+      if body.length > length
+        body[0..length] + '...'
+      else
+        body
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously it was incredibly difficult to determine whether you were
looking at a RestClient::Response object or a true String object.
Defining inspect makes this distinction much more understandable.